### PR TITLE
表示を大きく変更 #41

### DIFF
--- a/public/css/viewer.css
+++ b/public/css/viewer.css
@@ -3,3 +3,17 @@
     height: 160px;
     object-fit: cover;
 }
+
+
+@media screen and (max-width: 460px) {
+    .lum-lightbox-inner img {
+        max-width: 160vw;  /* 軽くスワイプで左端から右端まで動かせる量 */
+        max-height: 85vh;  /* 上下に適度に余白 */
+    }
+
+    .view {
+        width: 100px;
+        height: 80px;
+        object-fit: cover;
+    }
+}

--- a/public/javascript/pager.js
+++ b/public/javascript/pager.js
@@ -14,7 +14,7 @@ const makePageNav = (_images) => {
     $("#pagenav").append(`
         <li class="page-item" id="firstpage">
             <a class="page-link" href="#" aria-label="First" onclick="setPage('first')">
-                <span aria-hidden="true">最初</span>
+                <span aria-hidden="true">1ページ目へ</span>
             </a>
         </li>
         <li class="page-item" id="prevpage">
@@ -40,7 +40,7 @@ const makePageNav = (_images) => {
         </li>
         <li class="page-item" id="lastpage">
             <a class="page-link" href="#" aria-label="Last" onclick="setPage('last')">
-                <span aria-hidden="true">最後</span>
+                <span aria-hidden="true">${maxPage}ページ目へ</span>
             </a>
         </li>
     `)

--- a/views/layout.ejs
+++ b/views/layout.ejs
@@ -15,12 +15,27 @@
         integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script>
 </head>
 
-<body class="d-flex flex-column h-100" style="padding-top: 70px;">
+<body>
     <header>
-        <nav class=" navbar navbar-expand-md navbar-dark fixed-top bg-dark">
-            <a class="text-light" href="https://twitter.com">Twitter</a>
-            <ul class="navbar-nav mr-auto"></ul>
-            <a class="text-light" href="/">Top</a>
+        <nav class="navbar navbar-expand-lg navbar-light" style="background-color: #e3f2fd;">
+            <div class="container">
+                <a class="navbar-brand" href="/">TwitPictViewer</a>
+                <button type="button" class="navbar-toggler" data-toggle="collapse" data-target="#navbarNav"
+                    aria-controls="navbarNav" aria-expanded="false" aria-label="ナビゲーションの切替">
+                    <span class="navbar-toggler-icon"></span>
+                </button>
+                <div class="collapse navbar-collapse" id="navbarNav">
+                    <ul class="navbar-nav mr-auto"></ul>
+                    <ul class="navbar-nav">
+                        <li class="nav-item active">
+                            <a class="nav-link" href="https://twitter.com">Twitter</a>
+                        </li>
+                        <li class="nav-item active">
+                            <a class="nav-link" href="/">Top</a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
         </nav>
     </header>
     <div class="container">

--- a/views/viewer.ejs
+++ b/views/viewer.ejs
@@ -6,26 +6,27 @@
 
 <h1 class="mt-5">ユーザID: <%- id %></h1>
 
-<div id="spinner" class="spinner-border text-primary text-center" role="status" style="width: 6rem; height: 6rem;">
-    <span class="sr-only">Loading...</span>
+<div id="spinner" class="d-flex justify-content-center">
+    <div class="spinner-grow text-info" style="width: 6rem; height: 6rem;" role="status">
+        <span class="sr-only">Loading...</span>
+    </div>
 </div>
 
 <h1 id="imagescount"></h1>
 <div id="images"></div>
+<br>
 <div class="pagination justify-content-center" id="pagenav"></div>
+<br>
 
 <script type="text/javascript" src="/public/javascript/viewer.js"></script>
 <script type="text/javascript" src="/public/javascript/pager.js"></script>
 
 <script>
-    // ロード時に一覧取得
+    // ページ読み込みが完了したときに実行
     $(function () {
-        $.ajaxSetup({ async: false });
         $.getJSON(`/api/get_images?id=<%= id %>`, (images) => {
             $('#spinner').remove();
-            console.log(images);
             makePageNav(images);
         });
-        $.ajaxSetup({ async: true });
     });
 </script>


### PR DESCRIPTION
表示について変更した。
変更点は以下の通りである。
- ナビゲーションの色を変更
- ローディング(検索中)の表示の場所を中央にした
- スマホ用の画像一覧の表示サイズを変更
- 無駄なconsole.log()の削除
- 同期処理になっていた場所を非同期処理にした